### PR TITLE
[BugFix][Browser]Can't download music from music.baidu.com

### DIFF
--- a/src/com/android/browser/DownloadHandler.java
+++ b/src/com/android/browser/DownloadHandler.java
@@ -214,7 +214,9 @@ public class DownloadHandler {
         String cookies = CookieManager.getInstance().getCookie(url, privateBrowsing);
         request.addRequestHeader("cookie", cookies);
         request.addRequestHeader("User-Agent", userAgent);
-        request.addRequestHeader("Referer", referer);
+        if (!TextUtils.isEmpty(referer)) {
+            request.addRequestHeader("Referer", referer);
+        }
         request.setNotificationVisibility(
                 DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
         if (mimetype == null) {


### PR DESCRIPTION
[Solution Description]
    Can not download music from music.baidu.com
    The Referer is Empty

[Other Info]

    modified:   src/com/android/browser/DownloadHandler.java

Change-Id: If696c2ace282ec01f95476a9907fd6c7303bfb9c
(cherry picked from commit 2db66392f651d0b306e9921a9b005c6ed1361428)